### PR TITLE
Add link to 2019 Q1 OKRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 IPLD is a set of standards and implementations for creating decentralized data-structures that are universally addressable and linkable. These structures will allow us to do for data what URLs and links did for HTML web pages.
 
-This repo tracks project management issues like our bi-weekly call or quarterly OKRs planning. For general information about IPLD, refer to the [IPLD website](https://ipld.io.io/) or [the main repo](https://github.com/ipld/ipld).
+This repo tracks project management issues like our bi-weekly call or quarterly [OKRs](okr) planning. For general information about IPLD, refer to the [IPLD website](https://ipld.io.io/) or [the main repo](https://github.com/ipld/ipld).
 
 # Bi-weekly call
 

--- a/okr/README.md
+++ b/okr/README.md
@@ -2,6 +2,10 @@
 
 We frame our ongoing work using a process based on quarterly Objectives and Key Results (OKRs). Objectives reflect outcomes that are challenging, but realistic. Results are tangible and measurable.
 
+## 2019 Q1
+
+- [IPLD 2019 Q1 OKRs](https://github.com/ipld/roadmap/blob/master/okrs/2019-q1.md)
+
 ## 2018 Q4
 
 - [IPLD 2018 Q4 OKRs](https://docs.google.com/spreadsheets/d/1Lfd91hi3nFlLRS1r-FHvK2ip2Ll6ukraufCgepw43bw/edit#gid=35874512)


### PR DESCRIPTION
The OKRs now live in the https://github.com/ipld/roadmap repo.