### PR TITLE
Moving the bi-weekly meeting to half an hour earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo tracks project management issues like our bi-weekly call or quarterly 
 
 # Bi-weekly call
 
-We run a bi-weekly IPLD call every other (even weeks) **Monday 21:30–22:00 UTC**. You also find it on the [IPFS community calendar](https://calendar.google.com/calendar/embed?src=ipfs.io_eal36ugu5e75s207gfjcu0ae84@group.calendar.google.com&ctz=UTC)
+We run a bi-weekly IPLD call every other (even weeks) **Monday 21:00–21:30 UTC**. You also find it on the [IPFS community calendar](https://calendar.google.com/calendar/embed?src=ipfs.io_eal36ugu5e75s207gfjcu0ae84@group.calendar.google.com&ctz=UTC)
 
 Link to join the call: https://protocol.zoom.us/j/935904840 (note: it’s recorded, [live streamed](https://www.youtube.com/c/IPFS-dweb/live) and public)
 


### PR DESCRIPTION
The meeting time is now from Monday 21:00 - 21:30 UTC.